### PR TITLE
Feat/chunghyun_extension_color

### DIFF
--- a/Letports/Letports.xcodeproj/project.pbxproj
+++ b/Letports/Letports.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		411D4E542C635A8B00B07D84 /* Extension+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411D4E532C635A8B00B07D84 /* Extension+Color.swift */; };
 		D8201FB22C606934004DF06C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8201FB12C606934004DF06C /* AppDelegate.swift */; };
 		D8201FB42C606934004DF06C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8201FB32C606934004DF06C /* SceneDelegate.swift */; };
 		D8201FB62C606934004DF06C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8201FB52C606934004DF06C /* ViewController.swift */; };
@@ -35,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		411D4E532C635A8B00B07D84 /* Extension+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+Color.swift"; sourceTree = "<group>"; };
 		D8201FAE2C606934004DF06C /* Letports.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Letports.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8201FB12C606934004DF06C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D8201FB32C606934004DF06C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 				D8201FB72C606935004DF06C /* Assets.xcassets */,
 				D8201FB92C606935004DF06C /* LaunchScreen.storyboard */,
 				D8201FBC2C606935004DF06C /* Info.plist */,
+				411D4E532C635A8B00B07D84 /* Extension+Color.swift */,
 			);
 			path = Letports;
 			sourceTree = "<group>";
@@ -259,6 +262,7 @@
 				D8201FB62C606934004DF06C /* ViewController.swift in Sources */,
 				D8201FB22C606934004DF06C /* AppDelegate.swift in Sources */,
 				D8201FB42C606934004DF06C /* SceneDelegate.swift in Sources */,
+				411D4E542C635A8B00B07D84 /* Extension+Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Letports/Letports/Assets.xcassets/Color/Contents.json
+++ b/Letports/Letports/Assets.xcassets/Color/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Letports/Letports/Assets.xcassets/Color/lp_background_white.colorset/Contents.json
+++ b/Letports/Letports/Assets.xcassets/Color/lp_background_white.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Letports/Letports/Assets.xcassets/Color/lp_black.colorset/Contents.json
+++ b/Letports/Letports/Assets.xcassets/Color/lp_black.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.239",
+          "green" : "0.208",
+          "red" : "0.180"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Letports/Letports/Assets.xcassets/Color/lp_gray.colorset/Contents.json
+++ b/Letports/Letports/Assets.xcassets/Color/lp_gray.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.733",
+          "green" : "0.733",
+          "red" : "0.733"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Letports/Letports/Assets.xcassets/Color/lp_main.colorset/Contents.json
+++ b/Letports/Letports/Assets.xcassets/Color/lp_main.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.827",
+          "green" : "0.663",
+          "red" : "0.482"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Letports/Letports/Assets.xcassets/Color/lp_sub.colorset/Contents.json
+++ b/Letports/Letports/Assets.xcassets/Color/lp_sub.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.863",
+          "green" : "0.737",
+          "red" : "0.604"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Letports/Letports/Assets.xcassets/Color/lp_tint.colorset/Contents.json
+++ b/Letports/Letports/Assets.xcassets/Color/lp_tint.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.431",
+          "green" : "0.431",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Letports/Letports/Assets.xcassets/Color/lp_white.colorset/Contents.json
+++ b/Letports/Letports/Assets.xcassets/Color/lp_white.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Letports/Letports/Extension+Color.swift
+++ b/Letports/Letports/Extension+Color.swift
@@ -1,0 +1,70 @@
+//
+//  Extension+Color.swift
+//  Letports
+//
+//  Created by Chung Wussup on 8/7/24.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    convenience init(_ rgb: String, alpha: CGFloat = 1.0) {
+        guard rgb.hasPrefix("#") else {
+            fatalError("rgb does not start with a #.")
+        }
+        
+        let hexString = String(rgb[rgb.index(rgb.startIndex, offsetBy: 1) ..< rgb.endIndex])
+        
+        guard hexString.count == 6 else {
+            fatalError("hexString has an invalid length.")
+        }
+        
+        guard let hexValue = UInt32(hexString, radix: 16) else {
+            fatalError("hexString is not a hexadecimal.")
+        }
+        
+        let red = CGFloat((hexValue & 0xFF0000) >> 16) / CGFloat(255)
+        let green = CGFloat((hexValue & 0x00FF00) >> 8) / CGFloat(255)
+        let blue = CGFloat(hexValue & 0x0000FF) / CGFloat(255)
+        
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
+    
+    /// Letports Black - #2E353D
+    class var lp_black: UIColor {
+        return UIColor(named: "lp_black") ?? UIColor("#2E353D")
+    }
+
+    /// Letports White - #FFFFFF
+    class var lp_white: UIColor {
+        return UIColor(named: "lp_white") ?? UIColor("#FFFFFF")
+    }
+    
+    /// Letports White - #FFFFFF
+    class var lp_gray: UIColor {
+        return UIColor(named: "lp_gray") ?? UIColor("#BBBBBB")
+    }
+    
+    /// Letports Background White - #F4F4F4
+    class var lp_background_white: UIColor {
+        return UIColor(named: "lp_background_white") ?? UIColor("#F4F4F4")
+    }
+    
+    /// Letports Main - #7BA9D3
+    class var lp_main: UIColor {
+        return UIColor(named: "lp_main") ?? UIColor("#7BA9D3")
+    }
+    
+    /// Letports Tint - #FF6E6E
+    class var lp_tint: UIColor {
+        return UIColor(named: "lp_tint") ?? UIColor("#FF6E6E")
+    }
+    
+    /// Letports Sub - #9ABCDC
+    class var lp_sub: UIColor {
+        return UIColor(named: "lp_sub") ?? UIColor("#9ABCDC")
+    }
+        
+    
+}

--- a/Letports/Letports/ViewController.swift
+++ b/Letports/Letports/ViewController.swift
@@ -12,6 +12,9 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        self.view.backgroundColor = UIColor("#BBBBBB", alpha: 1.0)
+        self.view.backgroundColor = .lp_background_white
+    
     }
 
 


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 사용할 Custom Color extension 추가


- [x] 작업 내역 작성


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

### 📝 PR 특이 사항

- 각 컬러는 아래와 같이 명명함(lp = letports) 
-> lp_black, lp_white, lp_gray, lp_background_white, lp_main, lp_tint, lp_sub
- 해당 컬러 사용 시 기존 UIColor 사용 방법과 같이 .lp_main 과 같은 형태로 사용할 수 있음.
- Asset에도 Custom Color에 대한 Asset을 추가해 두었음.

```Swift
convenience init(_ rgb: String, alpha: CGFloat = 1.0)
``` 
- convenience init 을 추가해두어 아래와 같이 사용 가능함
```Swift
UIColor("#BBBBBB", alpha: 1.0)
```
<br/><br/>
