### PR TITLE
refactor:  소모임 리스트에서 리로드할시 저장된 캐시값이 아닌 최신데이터를 받아오도록 수정

### DIFF
--- a/Letports/Letports/Gathering/GatheringVC.swift
+++ b/Letports/Letports/Gathering/GatheringVC.swift
@@ -190,8 +190,6 @@ extension GatheringVC: UITableViewDelegate, UITableViewDataSource {
                     let (gathering, sports) = viewModel.recommendGatherings[gatheringIndex]
                     if let master = viewModel.masterUsers[gathering.gatheringMaster] {
                         cell.configure(with: gathering, with: sports, with: master)
-                    } else {
-                        viewModel.fetchMasterUser(masterId: gathering.gatheringMaster)
                     }
                 }
                 return cell
@@ -209,9 +207,7 @@ extension GatheringVC: UITableViewDelegate, UITableViewDataSource {
                     let (gathering, sports) = viewModel.gatheringLists[gatheringIndex]
                     if let master = viewModel.masterUsers[gathering.gatheringMaster] {
                         cell.configure(with: gathering, with: sports, with: master)
-                    } else {
-                        viewModel.fetchMasterUser(masterId: gathering.gatheringMaster)
-                    }
+                    } 
                 }
                 return cell
             }

--- a/Letports/Letports/Profile/Cell/GatheringTVCell.swift
+++ b/Letports/Letports/Profile/Cell/GatheringTVCell.swift
@@ -142,6 +142,7 @@ class GatheringTVCell: UITableViewCell {
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        self.selectionStyle = .default
     }
     
     override func prepareForReuse() {

--- a/Letports/Letports/Profile/ProfileVC.swift
+++ b/Letports/Letports/Profile/ProfileVC.swift
@@ -240,7 +240,6 @@ extension ProfileVC: UITableViewDelegate, UITableViewDataSource {
                     let (gathering, sports) = viewModel.myGatherings[gatheringIndex]
                     if let user = viewModel.user {
                         if let masterUser = viewModel.masterUsers[gathering.gatheringMaster] {
-                            cell.selectionStyle = .default
                             cell.configure(with: gathering, with: sports, with: user, with: masterUser)
                         } else {
                             viewModel.fetchMasterUser(masterId: gathering.gatheringMaster)
@@ -267,7 +266,6 @@ extension ProfileVC: UITableViewDelegate, UITableViewDataSource {
                     let (gathering, sports) = viewModel.pendingGatherings[gatheringIndex]
                     if let user = viewModel.user {
                         if let masterUser = viewModel.masterUsers[gathering.gatheringMaster] {
-                            cell.selectionStyle = .default
                             cell.configure(with: gathering, with: sports, with: user, with: masterUser)
                         } else {
                             viewModel.fetchMasterUser(masterId: gathering.gatheringMaster)

--- a/Letports/Letports/Service/AuthService.swift
+++ b/Letports/Letports/Service/AuthService.swift
@@ -121,8 +121,8 @@ class AuthService: AuthServiceProtocol {
             .flatMap { existingUser -> AnyPublisher<LetportsUser, FirestoreError> in
                 let updatedUser = LetportsUser(
                     email: user.email ?? existingUser.email,
-                    image: user.photoURL?.absoluteString ?? existingUser.image,
-                    nickname: user.displayName ?? existingUser.nickname,
+                    image: existingUser.image,
+                    nickname: existingUser.nickname,
                     simpleInfo: existingUser.simpleInfo,
                     uid: userID,
                     userSports: existingUser.userSports,


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 구글 로그인 로그인할때마다 닉네임, 사진 초기화되는 문제 해결
- [x] 소모임 리스트에서 리로드시 최신정보만 받아오도록수정 


### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br/><br/>
